### PR TITLE
fix: allow sending device type during login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frappe-js-sdk",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "frappe-js-sdk",
-      "version": "1.1.11",
+      "version": "1.1.12",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.26.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frappe-js-sdk",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "TypeScript/JavaScript client for Frappe Framework REST API",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -12,7 +12,7 @@ export class FrappeAuth {
 
   /** Logs in the user using username and password */
   async loginWithUsernamePassword(credentials: AuthCredentials): Promise<AuthResponse> {
-    const { username, password } = credentials;
+    const { username, password, device } = credentials;
 
     const headers: AxiosRequestHeaders = {
       Accept: 'application/json',
@@ -30,6 +30,7 @@ export class FrappeAuth {
         {
           usr: username,
           pwd: password,
+          device,
         },
         {
           headers,

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -1,6 +1,7 @@
 export interface AuthCredentials {
   username: string;
   password: string;
+  device?: string;
 }
 
 export interface AuthResponse {


### PR DESCRIPTION
For Frappe's versions 14 and lower, sending `device=mobile` during login allows users to avoid CORS issues when the [server sets the session cookies](https://github.com/frappe/frappe/blob/5cedae22ba5f30ec3535654cc2202c3013b4a564/frappe/auth.py#L359-L360).

This will require a different fix for v15+ after the changes made [here](https://github.com/frappe/frappe/pull/18728).