### PR TITLE
fix: use client instances to handle requests

### DIFF
--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -1,11 +1,14 @@
-import { Error } from '../frappe_app/types';
-import { getAxiosClient } from '../utils/axios';
 import { AxiosInstance } from 'axios';
+
+import { Error } from '../frappe_app/types';
 import { AuthCredentials, AuthResponse } from './types';
 
 export class FrappeAuth {
   /** URL of the Frappe App instance */
   private readonly appURL: string;
+
+  /** Axios instance */
+  readonly axios: AxiosInstance;
 
   /** Whether to use the token based auth */
   readonly useToken: boolean;
@@ -16,15 +19,18 @@ export class FrappeAuth {
   /** Type of token to be used for authentication */
   readonly tokenType?: 'Bearer' | 'token';
 
-  /** Axios instance */
-  private readonly axios: AxiosInstance;
-
-  constructor(appURL: string, useToken?: boolean, token?: () => string, tokenType?: 'Bearer' | 'token') {
+  constructor(
+    appURL: string,
+    axios: AxiosInstance,
+    useToken?: boolean,
+    token?: () => string,
+    tokenType?: 'Bearer' | 'token',
+  ) {
     this.appURL = appURL;
+    this.axios = axios;
     this.useToken = useToken ?? false;
     this.token = token;
     this.tokenType = tokenType;
-    this.axios = getAxiosClient(this.appURL, this.useToken, this.token, this.tokenType);
   }
 
   /** Logs in the user using username and password */

--- a/src/call/index.ts
+++ b/src/call/index.ts
@@ -1,10 +1,13 @@
 import { AxiosInstance } from 'axios';
+
 import { Error } from '../frappe_app/types';
-import { getAxiosClient } from '../utils/axios';
 
 export class FrappeCall {
   /** URL of the Frappe App instance */
   private readonly appURL: string;
+
+  /** Axios instance */
+  readonly axios: AxiosInstance;
 
   /** Whether to use the token based auth */
   readonly useToken: boolean;
@@ -15,15 +18,18 @@ export class FrappeCall {
   /** Type of token to be used for authentication */
   readonly tokenType?: 'Bearer' | 'token';
 
-  /** Axios instance */
-  private readonly axios: AxiosInstance;
-
-  constructor(appURL: string, useToken?: boolean, token?: () => string, tokenType?: 'Bearer' | 'token') {
+  constructor(
+    appURL: string,
+    axios: AxiosInstance,
+    useToken?: boolean,
+    token?: () => string,
+    tokenType?: 'Bearer' | 'token',
+  ) {
     this.appURL = appURL;
+    this.axios = axios;
     this.useToken = useToken ?? false;
     this.token = token;
     this.tokenType = tokenType;
-    this.axios = getAxiosClient(this.appURL, this.useToken, this.token, this.tokenType);
   }
 
   /** Makes a GET request to the specified endpoint */

--- a/src/call/index.ts
+++ b/src/call/index.ts
@@ -1,6 +1,7 @@
-import axios, { AxiosRequestHeaders } from 'axios';
+import { AxiosInstance } from 'axios';
 import { Error } from '../frappe_app/types';
-import { getRequestHeaders } from '../utils';
+import { getAxiosClient } from '../utils/axios';
+
 export class FrappeCall {
   /** URL of the Frappe App instance */
   private readonly appURL: string;
@@ -14,27 +15,21 @@ export class FrappeCall {
   /** Type of token to be used for authentication */
   readonly tokenType?: 'Bearer' | 'token';
 
+  /** Axios instance */
+  private readonly axios: AxiosInstance;
+
   constructor(appURL: string, useToken?: boolean, token?: () => string, tokenType?: 'Bearer' | 'token') {
     this.appURL = appURL;
     this.useToken = useToken ?? false;
     this.token = token;
     this.tokenType = tokenType;
-  }
-
-  private getPreparedRequestHeaders(): AxiosRequestHeaders {
-    return getRequestHeaders(this.useToken, this.tokenType, this.token);
+    this.axios = getAxiosClient(this.appURL, this.useToken, this.token, this.tokenType);
   }
 
   /** Makes a GET request to the specified endpoint */
   async get<T = any>(path: string, params?: Record<string, any>): Promise<T> {
-    const headers = this.getPreparedRequestHeaders();
-
-    return axios
-      .get(`${this.appURL}/api/method/${path}`, {
-        headers,
-        params,
-        withCredentials: true,
-      })
+    return this.axios
+      .get(`/api/method/${path}`, { params })
       .then((res) => res.data as T)
       .catch((error) => {
         throw {
@@ -48,19 +43,8 @@ export class FrappeCall {
 
   /** Makes a POST request to the specified endpoint */
   async post<T = any>(path: string, params?: any): Promise<T> {
-    const headers = this.getPreparedRequestHeaders();
-
-    return axios
-      .post(
-        `${this.appURL}/api/method/${path}`,
-        {
-          ...params,
-        },
-        {
-          withCredentials: true,
-          headers,
-        },
-      )
+    return this.axios
+      .post(`/api/method/${path}`, { ...params })
       .then((res) => res.data as T)
       .catch((error) => {
         throw {
@@ -74,19 +58,8 @@ export class FrappeCall {
 
   /** Makes a PUT request to the specified endpoint */
   async put<T = any>(path: string, params?: any): Promise<T> {
-    const headers = this.getPreparedRequestHeaders();
-
-    return axios
-      .put(
-        `${this.appURL}/api/method/${path}`,
-        {
-          ...params,
-        },
-        {
-          headers,
-          withCredentials: true,
-        },
-      )
+    return this.axios
+      .put(`/api/method/${path}`, { ...params })
       .then((res) => res.data as T)
       .catch((error) => {
         throw {
@@ -100,14 +73,8 @@ export class FrappeCall {
 
   /** Makes a DELETE request to the specified endpoint */
   async delete<T = any>(path: string, params?: any): Promise<T> {
-    const headers = this.getPreparedRequestHeaders();
-
-    return axios
-      .delete(`${this.appURL}/api/method/${path}`, {
-        headers,
-        params,
-        withCredentials: true,
-      })
+    return this.axios
+      .delete(`/api/method/${path}`, { params })
       .then((res) => res.data as T)
       .catch((error) => {
         throw {

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,11 +1,14 @@
 import { AxiosInstance } from 'axios';
-import { Filter, FrappeDoc, GetDocListArgs, GetLastDocArgs } from './types';
+
 import { Error } from '../frappe_app/types';
-import { getAxiosClient } from '../utils/axios';
+import { Filter, FrappeDoc, GetDocListArgs, GetLastDocArgs } from './types';
 
 export class FrappeDB {
   /** URL of the Frappe App instance */
   private readonly appURL: string;
+
+  /** Axios instance */
+  readonly axios: AxiosInstance;
 
   /** Whether to use the token based auth */
   readonly useToken: boolean;
@@ -16,15 +19,18 @@ export class FrappeDB {
   /** Type of token to be used for authentication */
   readonly tokenType?: 'Bearer' | 'token';
 
-  /** Axios instance */
-  private readonly axios: AxiosInstance;
-
-  constructor(appURL: string, useToken?: boolean, token?: () => string, tokenType?: 'Bearer' | 'token') {
+  constructor(
+    appURL: string,
+    axios: AxiosInstance,
+    useToken?: boolean,
+    token?: () => string,
+    tokenType?: 'Bearer' | 'token',
+  ) {
     this.appURL = appURL;
+    this.axios = axios;
     this.useToken = useToken ?? false;
     this.token = token;
     this.tokenType = tokenType;
-    this.axios = getAxiosClient(this.appURL, this.useToken, this.token, this.tokenType);
   }
 
   /**

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,9 @@
+/* eslint-disable */
+
+declare global {
+  interface Window {
+    csrf_token?: string;
+  }
+}
+
+export {};

--- a/src/file/index.ts
+++ b/src/file/index.ts
@@ -1,7 +1,7 @@
 import { FileArgs } from './types';
 import { Error } from '../frappe_app/types';
-import { getRequestHeaders } from '../utils';
-import axios, { AxiosRequestHeaders } from 'axios';
+import { getAxiosClient } from '../utils/axios';
+import { AxiosInstance } from 'axios';
 
 export class FrappeFileUpload {
   /** URL of the Frappe App instance */
@@ -16,15 +16,15 @@ export class FrappeFileUpload {
   /** Type of token to be used for authentication */
   readonly tokenType?: 'Bearer' | 'token';
 
+  /** Axios instance */
+  private readonly axios: AxiosInstance;
+
   constructor(appURL: string, useToken?: boolean, token?: () => string, tokenType?: 'Bearer' | 'token') {
     this.appURL = appURL;
     this.useToken = useToken ?? false;
     this.token = token;
     this.tokenType = tokenType;
-  }
-
-  private getPreparedRequestHeaders(): AxiosRequestHeaders {
-    return getRequestHeaders(this.useToken, this.tokenType, this.token);
+    this.axios = getAxiosClient(this.appURL, this.useToken, this.token, this.tokenType);
   }
 
   /**
@@ -57,11 +57,8 @@ export class FrappeFileUpload {
       }
     }
 
-    const headers = this.getPreparedRequestHeaders();
-
-    return axios
-      .post(`${this.appURL}/api/method/upload_file`, formData, {
-        headers,
+    return this.axios
+      .post('/api/method/upload_file', formData, {
         onUploadProgress: (progressEvent) => {
           if (onProgress) {
             onProgress(progressEvent.loaded, progressEvent.total);

--- a/src/file/index.ts
+++ b/src/file/index.ts
@@ -1,11 +1,14 @@
-import { FileArgs } from './types';
-import { Error } from '../frappe_app/types';
-import { getAxiosClient } from '../utils/axios';
 import { AxiosInstance } from 'axios';
+
+import { Error } from '../frappe_app/types';
+import { FileArgs } from './types';
 
 export class FrappeFileUpload {
   /** URL of the Frappe App instance */
   private readonly appURL: string;
+
+  /** Axios instance */
+  readonly axios: AxiosInstance;
 
   /** Whether to use the token based auth */
   readonly useToken: boolean;
@@ -16,15 +19,18 @@ export class FrappeFileUpload {
   /** Type of token to be used for authentication */
   readonly tokenType?: 'Bearer' | 'token';
 
-  /** Axios instance */
-  private readonly axios: AxiosInstance;
-
-  constructor(appURL: string, useToken?: boolean, token?: () => string, tokenType?: 'Bearer' | 'token') {
+  constructor(
+    appURL: string,
+    axios: AxiosInstance,
+    useToken?: boolean,
+    token?: () => string,
+    tokenType?: 'Bearer' | 'token',
+  ) {
     this.appURL = appURL;
+    this.axios = axios;
     this.useToken = useToken ?? false;
     this.token = token;
     this.tokenType = tokenType;
-    this.axios = getAxiosClient(this.appURL, this.useToken, this.token, this.tokenType);
   }
 
   /**

--- a/src/frappe_app/index.ts
+++ b/src/frappe_app/index.ts
@@ -18,7 +18,7 @@ export class FrappeApp {
   readonly token?: () => string;
 
   /** Type of token to be used for authentication */
-  readonly tokenType?: 'Bearer' | 'token'
+  readonly tokenType?: 'Bearer' | 'token';
 
   constructor(url: string, tokenParams: TokenParams, name?: string) {
     this.url = url;

--- a/src/frappe_app/index.ts
+++ b/src/frappe_app/index.ts
@@ -1,7 +1,9 @@
+import { AxiosInstance } from 'axios';
 import { FrappeAuth } from '..';
 import { FrappeCall } from '../call';
 import { FrappeDB } from '../db';
 import { FrappeFileUpload } from '../file';
+import { getAxiosClient } from '../utils/axios';
 import { TokenParams } from './types';
 
 export class FrappeApp {
@@ -10,6 +12,9 @@ export class FrappeApp {
 
   /** Name of the Frappe App instance */
   readonly name: string;
+
+  /** Axios instance */
+  readonly axios: AxiosInstance;
 
   /** Whether to use token based auth */
   readonly useToken: boolean;
@@ -26,22 +31,26 @@ export class FrappeApp {
     this.useToken = tokenParams.useToken ?? false;
     this.token = tokenParams.token;
     this.tokenType = tokenParams.type ?? 'Bearer';
+    this.axios = getAxiosClient(this.url, this.useToken, this.token, this.tokenType);
   }
 
   /** Returns a FrappeAuth object for the app */
   auth() {
-    return new FrappeAuth(this.url, this.useToken, this.token, this.tokenType);
+    return new FrappeAuth(this.url, this.axios, this.useToken, this.token, this.tokenType);
   }
+
   /** Returns a FrappeDB object for the app */
   db() {
-    return new FrappeDB(this.url, this.useToken, this.token, this.tokenType);
+    return new FrappeDB(this.url, this.axios, this.useToken, this.token, this.tokenType);
   }
 
+  /** Returns a FrappeFileUpload object for the app */
   file() {
-    return new FrappeFileUpload(this.url, this.useToken, this.token, this.tokenType);
+    return new FrappeFileUpload(this.url, this.axios, this.useToken, this.token, this.tokenType);
   }
 
+  /** Returns a FrappeCall object for the app */
   call() {
-    return new FrappeCall(this.url, this.useToken, this.token, this.tokenType);
+    return new FrappeCall(this.url, this.axios, this.useToken, this.token, this.tokenType);
   }
 }

--- a/src/frappe_app/types.ts
+++ b/src/frappe_app/types.ts
@@ -11,5 +11,5 @@ export interface TokenParams {
   /** Function that returns the token as a string - this could be fetched from LocalStorage or auth providers like Firebase, Auth0 etc. */
   token?: () => string;
   /** Type of token to be used for authentication */
-  type: 'Bearer' | 'token'
+  type: 'Bearer' | 'token';
 }

--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -1,4 +1,17 @@
-import { AxiosRequestHeaders } from 'axios';
+import axios, { AxiosInstance, AxiosRequestHeaders } from 'axios';
+
+export function getAxiosClient(
+  appURL: string,
+  useToken?: boolean,
+  token?: () => string,
+  tokenType?: 'Bearer' | 'token',
+): AxiosInstance {
+  return axios.create({
+    baseURL: appURL,
+    headers: getRequestHeaders(useToken, tokenType, token),
+    withCredentials: true,
+  });
+}
 
 export function getRequestHeaders(
   useToken: boolean = false,
@@ -17,8 +30,8 @@ export function getRequestHeaders(
   // in case of browser environments
   if (typeof window !== 'undefined') {
     headers['X-Frappe-Site-Name'] = window.location.hostname;
-    if ((window as any).csrf_token && (window as any).csrf_token !== '{{ csrf_token }}') {
-      headers['X-Frappe-CSRF-Token'] = (window as any).csrf_token;
+    if (window.csrf_token && window.csrf_token !== '{{ csrf_token }}') {
+      headers['X-Frappe-CSRF-Token'] = window.csrf_token;
     }
   }
 


### PR DESCRIPTION
Now that we have a client, we could even add [interceptors](https://axios-http.com/docs/interceptors) if we wanted to do things like error handling without needing to specify it per request.